### PR TITLE
Add getBalance() method to retrieve account balance

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,18 @@ async function getStatus() {
 
 getStatus()
 ```
+
+## Get Balance
+
+```js
+const { MessageWay } = require('messageway')
+const message = new MessageWay(API_KEY)
+
+message.getBalance()
+  .then(balanceInfo => {
+    console.log('Balance info:', balanceInfo)
+  })
+  .catch(error => {
+    console.error('Error while fetching balance:', error)
+  })
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import got from 'got'
-import { SendInput, SendManuallyInput, SendAutomaticInput, VerifyRequest, StatusRequest, StatusResponse, MessageError, SendRequest, SendResponse, MessengerProvider } from './types'
+import { SendInput, SendManuallyInput, SendAutomaticInput, VerifyRequest, StatusRequest, StatusResponse, MessageError, SendRequest, SendResponse, MessengerProvider, BalanceResponse } from './types'
 export { SendInput, SendManuallyInput as SendManuallyInput, SendAutomaticInput, VerifyRequest, StatusRequest, StatusResponse, MessageError as OTPError }
 export { MessageMethod as OTPMethod, MessageStatus as OTPStatus } from './types'
 
@@ -25,13 +25,14 @@ export class MessageWay<IsManual extends boolean = false> {
     private readonly apiKey: string,
     manual: IsManual = false as IsManual,
     private readonly language = 'fa-IR') {
-      this.sendSMS = this.sendSMS.bind(this)
-      this.sendIVR = this.sendIVR.bind(this)
-      this.sendGapMessage = this.sendGapMessage.bind(this)
-      this.verify = this.verify.bind(this)
-      this.getStatus = this.getStatus.bind(this)
+    this.sendSMS = this.sendSMS.bind(this)
+    this.sendIVR = this.sendIVR.bind(this)
+    this.sendGapMessage = this.sendGapMessage.bind(this)
+    this.verify = this.verify.bind(this)
+    this.getStatus = this.getStatus.bind(this)
+    this.getBalance = this.getBalance.bind(this)
   }
-  
+
   private request<T>(path: string, body: object): Promise<T> {
     let language = this.language
 
@@ -66,7 +67,7 @@ export class MessageWay<IsManual extends boolean = false> {
       })
       .catch((error: any) => {
         if (error.response) {
-          try { error = JSON.parse(error.response.body) } catch (error) {}
+          try { error = JSON.parse(error.response.body) } catch (error) { }
         }
         if (error.status === 'error' && isMessageWayError(error.error)) {
           return Promise.reject(error.error)
@@ -122,7 +123,7 @@ export class MessageWay<IsManual extends boolean = false> {
    */
   verify(options: VerifyRequest): Promise<void> {
     return this.request<void>('/otp/verify', options)
-      .then(() => {})
+      .then(() => { })
   }
 
   /**
@@ -131,5 +132,15 @@ export class MessageWay<IsManual extends boolean = false> {
    */
   getStatus(options: StatusRequest): Promise<StatusResponse> {
     return this.request<StatusResponse>('/status', options)
+  }
+
+  /**
+   * Get account balance.
+   * @returns A promise that resolves to the account balance as a number.
+   * @author amirmm4d
+   */
+  getBalance(): Promise<number> {
+    return this.request<BalanceResponse>('/balance/get', {})
+      .then(result => result.balance)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,12 +25,12 @@ export class MessageWay<IsManual extends boolean = false> {
     private readonly apiKey: string,
     manual: IsManual = false as IsManual,
     private readonly language = 'fa-IR') {
-    this.sendSMS = this.sendSMS.bind(this)
-    this.sendIVR = this.sendIVR.bind(this)
-    this.sendGapMessage = this.sendGapMessage.bind(this)
-    this.verify = this.verify.bind(this)
-    this.getStatus = this.getStatus.bind(this)
-    this.getBalance = this.getBalance.bind(this)
+      this.sendSMS = this.sendSMS.bind(this)
+      this.sendIVR = this.sendIVR.bind(this)
+      this.sendGapMessage = this.sendGapMessage.bind(this)
+      this.verify = this.verify.bind(this)
+      this.getStatus = this.getStatus.bind(this)
+      this.getBalance = this.getBalance.bind(this)
   }
 
   private request<T>(path: string, body: object): Promise<T> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,8 +139,7 @@ export class MessageWay<IsManual extends boolean = false> {
    * @returns A promise that resolves to the account balance as a number.
    * @author amirmm4d
    */
-  getBalance(): Promise<number> {
+  getBalance(): Promise<BalanceResponse> {
     return this.request<BalanceResponse>('/balance/get', {})
-      .then(result => result.balance)
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-
 interface RequestOptions {
   language?: string
 }
@@ -51,7 +50,7 @@ export interface SendAutomaticInput extends SendInputCommon {
 export type SendInput<IsManual extends boolean> = IsManual extends true ? SendManuallyInput : SendAutomaticInput
 
 /** @ignore */
- export interface SendRequest {
+export interface SendRequest {
   code: string
   countryCode?: number
   expireTime?: number
@@ -78,7 +77,7 @@ export interface VerifyRequest {
 }
 
 export interface StatusRequest {
-  OTPReferenceID:	string
+  OTPReferenceID: string
 }
 
 export interface StatusResponse {
@@ -88,4 +87,8 @@ export interface StatusResponse {
   MessageStatus: MessageStatus
   /** Is OTP verified */
   OTPVerified: boolean
+}
+
+export interface BalanceResponse {
+  balance: number
 }


### PR DESCRIPTION
This pull request adds a new method getBalance() to the MessageWay class,
which allows clients to retrieve the current credit balance from the MsgWay API
using the /balance/get endpoint.

Tested and verified using an API key.

Also, please make sure that when data is sent from the server, the response includes error: null, just like in the other methods,
so the structure expected by the got method doesn't need to be changed.